### PR TITLE
FunctionArg compatible array signature

### DIFF
--- a/src/edge/core/macro/Macros.hx
+++ b/src/edge/core/macro/Macros.hx
@@ -11,7 +11,7 @@ class Macros {
     return fields
       .map(function(field) return switch field.kind {
         case FVar(t, _) if(!field.isStatic()):
-          { name : field.name, type : t, opt : null, value : null }
+          { name : field.name, type : t, opt : null, value : null, meta : null }
         case _:
           null;
       })


### PR DESCRIPTION
Issue https://github.com/fponticelli/edge/issues/18

Explanation as to why it has to be like that - https://github.com/HaxeFoundation/haxe/issues/2878

I'm not certain, but this could mean BC break on haxe < 3.3
