### PR TITLE
IComponent inheritance

### DIFF
--- a/src/edge/core/macro/BuildComponent.hx
+++ b/src/edge/core/macro/BuildComponent.hx
@@ -2,40 +2,72 @@ package edge.core.macro;
 
 import haxe.macro.Context;
 import haxe.macro.Expr;
+import haxe.macro.Type;
 using thx.macro.MacroFields;
 
 import edge.core.macro.Macros.*;
 
 class BuildComponent {
   macro public static function complete() : Array<Field> {
-    var fields = Context.getBuildFields();
+    var fields = Context.getBuildFields(),
+        cls = Context.getLocalClass().get();
     makeVarsPublic(fields);
-    injectToString(fields);
-    injectConstructor(fields);
+    injectToString(fields, cls);
+    injectConstructor(fields, cls);
     return fields;
   }
 
-  static function injectConstructor(fields : Array<Field>) {
+  static function injectConstructor(fields : Array<Field>, type : ClassType) {
     if(hasField(fields, "new")) return;
     var args = getVarAsFunctionArgs(fields),
         init = args
           .map(function(arg) return arg.name)
           .map(function(name) return macro this.$name = $i{name});
+
+    var ancestor:Null<ClassType> = getAncestor(type),
+        ancestorArgs:Array<FunctionArg> = [];
+
+    if (ancestor != null) {
+      do {
+        //Reverse concat, to make sure ancestor arguments are first
+        var funArgs = getClassVarAsFunctionArgs(ancestor.fields.get());
+        args = funArgs.concat(args);
+        ancestorArgs = funArgs.concat(ancestorArgs);
+        type = ancestor;
+      } while((ancestor = getAncestor(type)) != null);      
+
+      var a = ancestorArgs.map(function(arg) return macro $i{arg.name});
+      init.unshift(macro super($a{a}));
+    }
     fields.push(createFunctionField("new", args, macro $b{init}));
   }
 
-  static function injectToString(fields : Array<Field>) {
+  static function injectToString(fields : Array<Field>, type : ClassType) {
     if(hasField(fields, "toString")) return;
+    var args = getVarAsFunctionArgs(fields),
+        access = [APublic];
+
+    var ancestor:Null<ClassType> = getAncestor(type);
+    if (ancestor != null) {
+      access.push(AOverride);
+      do {
+        //Reverse concat, to make sure ancestor arguments are first
+        args = getClassVarAsFunctionArgs(ancestor.fields.get()).concat(args);
+        type = ancestor;
+      } while((ancestor = getAncestor(type)) != null);
+    }
+
     var cls  = clsName().split(".").pop(),
-        args = getVarAsFunctionArgs(fields),
         params = args
           .map(function(arg) return '${arg.name}=$' + arg.name)
           .join(","),
         s = 'return \'$cls($params)\'';
     fields.push(createFunctionField(
       "toString",
-      args,
+      [],
       macro : String,
-      Context.parse(s, Context.currentPos())));
+      Context.parse(s, Context.currentPos()),
+      access)
+    );
   }
 }

--- a/src/edge/core/macro/Macros.hx
+++ b/src/edge/core/macro/Macros.hx
@@ -3,6 +3,7 @@ package edge.core.macro;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
+using haxe.macro.TypeTools;
 using thx.macro.MacroFields;
 import Type in RType;
 
@@ -17,6 +18,17 @@ class Macros {
       })
       .filter(function(field) return field != null);
   }
+  
+  public static function getClassVarAsFunctionArgs(fields : Array<ClassField>) : Array<FunctionArg> {
+    return fields
+      .map(function(field) return switch field.kind {
+        case FVar(t, _):
+          { name : field.name, type : field.type.follow().toComplexType(), opt : null, value : null, meta : null }
+        case _:
+          null;
+      })
+      .filter(function(field) return field != null);
+  }
 
   public static function createVarField(name : String, type : ComplexType) : Field {
     return {
@@ -26,10 +38,10 @@ class Macros {
     };
   }
 
-  public static function createFunctionField(name : String, ?args : Array<FunctionArg>, ?ret : ComplexType, ?expr : Expr) : Field {
+  public static function createFunctionField(name : String, ?args : Array<FunctionArg>, ?ret : ComplexType, ?expr : Expr, ?access : Array<Access>) : Field {
     return {
       name: name,
-      access: [APublic],
+      access: null != access ? access : [APublic],
       kind: FFun({
         ret  : null != ret ? ret : macro : Void,
         expr : null != expr ? expr : macro {},
@@ -157,5 +169,13 @@ class Macros {
       case _:
         return null;
     }
+  }
+
+  public static function getAncestor(type : ClassType):Null<ClassType>
+  {
+    var c = type.superClass;
+    if (c == null) return null;
+
+    return c.t.get();
   }
 }

--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -240,6 +240,21 @@ class TestAll {
     Assert.equals(0, system.count);
   }
 
+  public function testInheritedConstructor() {
+    for(field in haxe.rtti.Rtti.getRtti(E).fields) {
+      if (field.name == "new") {
+        switch (field.type) {
+          case CFunction(args, returnType):
+              Assert.equals(args.length, 3);
+          default:
+        }
+      }
+    }
+  }
+
+  public function testInheritedToString()
+    Assert.equals((new E(1, 2, 3)).toString(), "E(foo=$foo,bar=$bar,foobar=$foobar)");
+
   public function assertNumberOfComponents(entity : Entity, qt : Int, ?pos : haxe.PosInfos)
     Assert.equals(qt, entity.components().toArray().length, pos);
 
@@ -372,7 +387,18 @@ class B {
   public function new(){}
 }
 
+class C implements IComponent {
+  public var foo:Int;
+}
 
+class D extends C {
+  public var bar:Int;
+}
+
+@:rtti
+class E extends D {
+  public var foobar:Int;
+}
 
 class ReturnSystem implements ISystem {
   public var count(default, null) = 0;


### PR DESCRIPTION
Allows extending classes (nested inheritance supported) implementing IComponent without losing any magic, i.e. 

``` haxe
class Component implements IComponent
{
    var foo:Int;
}

class Component2 extends Component
{
    var bar:Int;
}
```
