### PR TITLE
Resolve Type before TInst check

### DIFF
--- a/src/edge/core/macro/BuildSystem.hx
+++ b/src/edge/core/macro/BuildSystem.hx
@@ -70,7 +70,7 @@ class BuildSystem {
             case TPath(p):
               if(p.params.length > 0)
                 Context.error('argument `${arg.name}` of ${clsName()}.update() cannot have type parameters', Context.currentPos());
-              var t = Context.getType(p.name);
+              var t = Context.getType(p.name).follow();
               switch t {
                 case TInst(s, _) if(s.toString() != "String"):
                   // TODO, should we support enums?


### PR DESCRIPTION
Given system `system.X` and `component.X`, if we import the component and use an alias, it's no longer `TInst`, but `TType`. This causes `argument x of system.X.update() is not a class instance`.

``` haxe
package system;

import edge.ISystem;

import component.X as XComponent;

class X implements ISystem
{
    public function update(x:XComponent) {}
}
```

Adding `.follow()` to `Context.getType(p.name)` resolves the problem
