### PR TITLE
added minor mention to special `updateItems` view

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ ${viewFieldName}Added
 
 The same signature with `Removed` can be used to define a method that does some cleanup when an entity is unpaired from a view.
 
-A special `View` is created for the method `update`. For that you can define either, both or neither of `updateAdded`/`updateRemoved` methods.
+A special `View` is created for the method `update` called `updateItems`. For that you can define either, both or neither of `updateAdded`/`updateRemoved` methods.
 
 For this `update` function:
 


### PR DESCRIPTION
In my usage of the library, it is sometimes important to have access to the full list of items specified by the `update` function. In order to do this, I had to dig through the macros to find the `updateItems` name, so I just added a small note mentioning it on the README.
